### PR TITLE
ci: add .nojekyll file

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "storybook dev -p 6006",
-    "build": "storybook build",
+    "build": "storybook build && touch ./storybook-static/.nojekyll",
     "deploy-storybook": "storybook-to-ghpages"
   },
   "keywords": [],


### PR DESCRIPTION
Esse PR evita o erro `TypeError: Failed to fetch dynamically imported module` que ocorre com o Storybook em produção.